### PR TITLE
Adds method required for JSON:API

### DIFF
--- a/src/Plugin/Field/FieldType/LangItem.php
+++ b/src/Plugin/Field/FieldType/LangItem.php
@@ -62,4 +62,8 @@ class LangItem extends FieldItemBase {
     return $value === NULL || $value === '';
   }
 
+  public static function mainPropertyName() {
+    return 'lang';
+  }
+
 }

--- a/src/Plugin/Field/FieldType/LangItem.php
+++ b/src/Plugin/Field/FieldType/LangItem.php
@@ -62,6 +62,9 @@ class LangItem extends FieldItemBase {
     return $value === NULL || $value === '';
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public static function mainPropertyName() {
     return 'lang';
   }

--- a/src/Plugin/Field/FieldType/MultilineStringWithOptionalLangItem.php
+++ b/src/Plugin/Field/FieldType/MultilineStringWithOptionalLangItem.php
@@ -70,4 +70,11 @@ class MultilineStringWithOptionalLangItem extends FieldItemBase {
     return $value === NULL || $value === '';
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    return 'multiline';
+  }
+
 }

--- a/src/Plugin/Field/FieldType/StringWithOptionalLangItem.php
+++ b/src/Plugin/Field/FieldType/StringWithOptionalLangItem.php
@@ -127,4 +127,11 @@ class StringWithOptionalLangItem extends FieldItemBase {
     return $value === NULL || $value === '';
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function mainPropertyName() {
+    return 'string';
+  }
+
 }


### PR DESCRIPTION
Drupal JSONAPI could not handle `lang` property being the main (and only) property. It was looking for the `value` property instead.
Adding `LangItem::mainPropertyName` method fixes this problem.